### PR TITLE
Updates to work with parsec 150-86e

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See base-image/image
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 
 COPY bin/install_clean /usr/bin/install_clean
 RUN chmod +x /usr/bin/install_clean
@@ -7,7 +7,8 @@ RUN chmod +x /usr/bin/install_clean
 # parsec dependencies + sound + gpu (install_clean is a wrapper around apt-get)
 RUN install_clean libcairo2 libfreetype6 libgdk-pixbuf2.0-0 libgl1-mesa-glx libgl1 libglib2.0-0 libgtk2.0-0 \ 
     libpango-1.0-0 libpangocairo-1.0-0 libsm6 libxxf86vm1 pulseaudio-utils libgl1-mesa-glx \
-    libgl1-mesa-dri xserver-xorg-video-intel pulseaudio libva2 i965-va-driver
+    libgl1-mesa-dri xserver-xorg-video-intel pulseaudio libva2 i965-va-driver \
+    libavcodec58 libssl3 ca-certificates
 
 # Parsec Client
 RUN install_clean wget \

--- a/parsec
+++ b/parsec
@@ -14,7 +14,7 @@ if [[ "$USERID" != "1000" ]] || [[ "$GROUPID" != "1000" ]]; then
 fi
 
 echo "launching parsec: (u${USERID}:g${GROUPID})"
-docker run -it --rm \
+docker run -it --rm --init \
  --env DISPLAY \
  --env PULSE_SERVER \
  -v /tmp/.X11-unix:/tmp/.X11-unix \


### PR DESCRIPTION
Updates to work with parsec 150-86e.

Builds off jammy (22.04) base rather than bionic (18.04), and includes new required dependencies (`libavcodec58` and `libssl3`) and also `ca-certificates` to allow SSL to work for authentication (Rather than giving `MTY_TLSHandshake: 'SSL_do_handhsake' failed with error -1:1` errors).

Also now runs with `--init` to allow `ctrl+c`ing the process when run from CLI.