### PR TITLE
Add libcurl4 libcurl4-openssl-dev dependencies for latest parsec and update scripts.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN chmod +x /usr/bin/install_clean
 RUN install_clean libcairo2 libfreetype6 libgdk-pixbuf2.0-0 libgl1-mesa-glx libgl1 libglib2.0-0 libgtk2.0-0 \ 
     libpango-1.0-0 libpangocairo-1.0-0 libsm6 libxxf86vm1 pulseaudio-utils libgl1-mesa-glx \
     libgl1-mesa-dri xserver-xorg-video-intel pulseaudio libva2 i965-va-driver \
-    libavcodec58 libssl3 ca-certificates
+    libavcodec58 libssl3 ca-certificates libcurl4 libcurl4-openssl-dev
 
 # Parsec Client
 RUN install_clean wget \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ docker pull ghcr.io/jaredallard/docker-parsec
 
 ## Tags
 
-* `latest` latest parsec client version
+* `main` latest parsec client version
 * `146` 28th April 2018 (`-18`)
 * `146-18` 15th June 2018
 

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-docker build -t jaredallard/parsec:latest .
-docker push jaredallard/parsec:latest
+docker build -t ghcr.io/jaredallard/docker-parsec:main .
+docker push ghcr.io/jaredallard/docker-parsec:main

--- a/parsec
+++ b/parsec
@@ -21,4 +21,4 @@ docker run -it --rm --init \
  -v "/run/user/$USERID/pulse:/run/user/1000/pulse" \
  --device /dev/dri \
  --net=host \
- ghcr.io/jaredallard/docker-parsec:latest app_daemon=1
+ ghcr.io/jaredallard/docker-parsec:main app_daemon=1


### PR DESCRIPTION
Add libcurl4 libcurl4-openssl-dev dependencies for latest parsec and update scripts.